### PR TITLE
feat(registry-creds): add pod monitor support

### DIFF
--- a/charts/registry-creds/Chart.yaml
+++ b/charts/registry-creds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: registry-creds
 description: A Helm chart alexellis/registry-creds
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: 0.2.5

--- a/charts/registry-creds/templates/deployment.yaml
+++ b/charts/registry-creds/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/registry-creds/templates/podmonitor.yaml
+++ b/charts/registry-creds/templates/podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.podMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "registry-creds.fullname" . }}
+  {{- if .Values.podMonitor.namespace }}
+  namespace: {{ .Values.podMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- toYaml .Values.podMonitor.labels | nindent 4 }}
+spec:
+  jobLabel: {{ include "registry-creds.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - interval: {{ .Values.podMonitor.interval }}
+      port: metrics
+  sampleLimit: {{ .Values.podMonitor.sampleLimit }}
+  selector:
+    matchLabels:
+      {{- include "registry-creds.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/registry-creds/values.yaml
+++ b/charts/registry-creds/values.yaml
@@ -48,3 +48,16 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podMonitor:
+  # Specifies whether PodMonitor should be created
+  create: false
+   # The Prometheus scrape interval
+  interval: 30s
+  # The number of scraped samples that will be accepted
+  sampleLimit: 5000
+   # Additional labels to add to the metadata
+  labels: {}
+  # Specifies whether a pod monitor should be created in a different namespace than
+  # the Helm release
+  # namespace: monitoring


### PR DESCRIPTION
This PR adds pod monitor support to registry-creds chart.