### PR TITLE
fix(ingress): api version

### DIFF
--- a/charts/op-scim-bridge/Chart.yaml
+++ b/charts/op-scim-bridge/Chart.yaml
@@ -19,3 +19,8 @@ dependencies:
     version: 12.0.0
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x

--- a/charts/op-scim-bridge/templates/ingress.yaml
+++ b/charts/op-scim-bridge/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "op-scim-bridge.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
To prevent ArgoCD to spam us the warning
`0302 08:48:17.921129 1 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress`